### PR TITLE
Avoid bash's filename expansion when calling `tr`

### DIFF
--- a/lib/bash+.bash
+++ b/lib/bash+.bash
@@ -60,7 +60,7 @@ bash+:fcopy() {
 
 # Find the path of a library
 bash+:findlib() {
-  local library_name="$(tr [A-Z] [a-z] <<< "${1//:://}").bash"
+  local library_name="$(tr 'A-Z' 'a-z' <<< "${1//:://}").bash"
   local lib="${BASHPLUSLIB:-${BASHLIB:-$PATH}}"
   library_name="${library_name//+/\\+}"
   find ${lib//:/ } -name ${library_name##*/} 2>/dev/null |


### PR DESCRIPTION
If you happen to have one or more filenames with a single letter, they
will be expanded and you will end up with a call to `tr [A-Z] a b c z`
for example.

In my case it was:

```
    [carlos@multi git-hub]$ make test
    prove test/
    test/args.t ...... tr: extra operand `a'
    Try `tr --help' for more information.
    Can't find library 'Test::More'. at line 5 in main of test/args.t
    test/args.t ...... Dubious, test returned 1 (wstat 256, 0x100)
    No subtests run
```
